### PR TITLE
add a simple brain

### DIFF
--- a/1.3/Defs/Body.xml
+++ b/1.3/Defs/Body.xml
@@ -69,6 +69,16 @@
                     <li>UpperHead</li>
                     <li>FullHead</li>
                   </groups>
+                  <parts>
+                    <li>
+                      <def>Brain</def>
+                      <coverage>0.8</coverage>
+                      <groups>
+                        <li>UpperHead</li>
+                        <li>FullHead</li>
+                      </groups>
+                    </li>
+                  </parts>
                 </li>
                 <li>
                   <def>Jaw</def>


### PR DESCRIPTION
Just to have and keep a Psylink.

I simply copied over the Human PawnKind from the base definition and removed the reference to the rest of the head's organs (eyes, ears ... ).